### PR TITLE
Modified interface builder to generate enumeratuibs as Typescript enums

### DIFF
--- a/server/models/interfaceBuilderResult.ts
+++ b/server/models/interfaceBuilderResult.ts
@@ -1,0 +1,5 @@
+export interface InterfaceBuilderResult {
+  interfaceDependencies: string[];
+  interfaceEnums: string[];
+  interfaceText: string;
+}

--- a/server/models/schemaInfo.ts
+++ b/server/models/schemaInfo.ts
@@ -11,6 +11,7 @@ export interface SchemaInfo {
   noRelationsInterfaceAsText: string;
   adminPanelLifeCycleRelationsInterfaceAsText: string;
   dependencies: string[];
+  enums: string[];
 }
 
 const defaultSchemaInfo: SchemaInfo = {
@@ -24,6 +25,7 @@ const defaultSchemaInfo: SchemaInfo = {
   adminPanelLifeCycleRelationsInterfaceAsText: '',
   schema: undefined,
   dependencies: [],
+  enums: [],
 };
 
 export default defaultSchemaInfo;

--- a/server/schemas-to-ts/commonHelpers.ts
+++ b/server/schemas-to-ts/commonHelpers.ts
@@ -35,7 +35,11 @@ export class CommonHelpers {
     return fileName;
   }
 
-  public static isWindows() {
+  public static isWindows(): boolean {
     return process.platform === 'win32';
+  }
+
+  public static capitalizeFirstLetter(text: string): string {
+    return text.charAt(0).toUpperCase() + text.slice(1);
   }
 }

--- a/server/schemas-to-ts/converter.ts
+++ b/server/schemas-to-ts/converter.ts
@@ -116,6 +116,7 @@ export class Converter {
       noRelationsInterfaceAsText: '',
       adminPanelLifeCycleRelationsInterfaceAsText: '',
       dependencies: [],
+      enums: [],
     };
   }
 


### PR DESCRIPTION
Strapi enumerations will be now treated in the same way dependencies are: put all together in an array, then adding only the different ones to the interface text.

The main changes in this commit are:
- Created InterfaceBuilderResult interface
- Created capitalizeFirstLetter static helper method
- Added enums array property to SchemaInfo interface
- Modified buildInterfaceText method to work with an array of dependencies and another array of enums and then return them together with the interface text in an object of InterfaceBuilderResult type.
- Modified convertToInterface method to work with an InterfaceBuilderResult object and push the interface enums to the schemaInfo enums array property