### PR TITLE
fix: escape single quotes in enum values

### DIFF
--- a/server/schemas-to-ts/interface-builders/interfaceBuilder.ts
+++ b/server/schemas-to-ts/interface-builders/interfaceBuilder.ts
@@ -374,6 +374,10 @@ export abstract class InterfaceBuilder {
           if (!isNaN(parseFloat(key))) {
             key = '_' + key;
           }
+
+          // Escape single quotes to avoid compilation errors
+          value = value.replace(/'/g, "\\'");
+
           return `  ${key} = '${value}',`;
         }).join('\n');
         const enumText: string = `export enum ${enumName} {\n${enumOptions}}`;


### PR DESCRIPTION
Fixes #35 

Single quotes in enum values would end string early causing an error in the final output