### PR TITLE
Escape single quotes in enum value generation

### DIFF
--- a/server/schemas-to-ts/interface-builders/interfaceBuilder.ts
+++ b/server/schemas-to-ts/interface-builders/interfaceBuilder.ts
@@ -374,7 +374,7 @@ export abstract class InterfaceBuilder {
           if (!isNaN(parseFloat(key))) {
             key = '_' + key;
           }
-          return `  ${key} = '${value.replace('\', '\\\'')}',`;
+          return `  ${key} = '${value.replace('\'', '\\\'')}',`;
         }).join('\n');
         const enumText: string = `export enum ${enumName} {\n${enumOptions}}`;
         interfaceEnums.push(enumText);

--- a/server/schemas-to-ts/interface-builders/interfaceBuilder.ts
+++ b/server/schemas-to-ts/interface-builders/interfaceBuilder.ts
@@ -374,7 +374,7 @@ export abstract class InterfaceBuilder {
           if (!isNaN(parseFloat(key))) {
             key = '_' + key;
           }
-          return `  ${key} = '${value}',`;
+          return `  ${key} = '${value.replace('\', '\\\'')}',`;
         }).join('\n');
         const enumText: string = `export enum ${enumName} {\n${enumOptions}}`;
         interfaceEnums.push(enumText);


### PR DESCRIPTION
Single quotes must be escaped with a backslash.
For example
```ts
enum Test { JacksComputer = 'Jack's Computer' }
```
Must be escaped like so:
```ts
enum Test { JacksComputer = 'Jack\'s Computer' }
```