### PR TITLE
Fix/improving pr57

### DIFF
--- a/server/models/destinationPaths.ts
+++ b/server/models/destinationPaths.ts
@@ -9,7 +9,7 @@ export class DestinationPaths {
   public apis?: string;
   public components?: string;
   public extensions?: string;
-  public readonly useForApisAndComponents: boolean;
+  public readonly useCustomDestinationFolder: boolean;
   public readonly componentInterfacesFolderName: string = 'interfaces';
   public readonly extensionsFolderName: string = 'extensions';
 
@@ -33,7 +33,7 @@ export class DestinationPaths {
       this.commons = FileHelpers.ensureFolderPathExistRecursive(strapiPaths.app.src, this.commonFolderName, config.commonInterfacesFolderName);
     }
 
-    this.useForApisAndComponents = !!destinationFolder;
+    this.useCustomDestinationFolder = !!destinationFolder;
   }
 
   private getFinalDestinationFolder(destinationFolder: string, strapiPaths: StrapiDirectories) {

--- a/server/models/destinationPaths.ts
+++ b/server/models/destinationPaths.ts
@@ -11,27 +11,26 @@ export class DestinationPaths {
   public extensions?: string;
   public readonly useForApisAndComponents: boolean;
   public readonly componentInterfacesFolderName: string = 'interfaces';
+  public readonly extensionsFolderName: string = 'extensions';
 
   private readonly apisFolderName: string = 'api';
   private readonly commonFolderName: string = 'common';
   private readonly componentsFolderName: string = 'components';
-  private readonly extensionsFolderName: string = 'extensions';
 
   constructor(config: PluginConfig, strapiPaths: StrapiDirectories) {
     let useDefaultFolders: boolean = true;
     let destinationFolder: string = config.destinationFolder;
     if (destinationFolder) {
       destinationFolder = this.getFinalDestinationFolder(destinationFolder, strapiPaths);
+      config.destinationFolder = destinationFolder;
       this.commons = FileHelpers.ensureFolderPathExistRecursive(destinationFolder, this.commonFolderName);
       this.apis = FileHelpers.ensureFolderPathExistRecursive(destinationFolder, this.apisFolderName);
       this.components = FileHelpers.ensureFolderPathExistRecursive(destinationFolder, this.componentsFolderName);
-      this.extensions = FileHelpers.ensureFolderPathExistRecursive(destinationFolder, this.extensionsFolderName);
       useDefaultFolders = false;
     }
 
     if (useDefaultFolders) {
       this.commons = FileHelpers.ensureFolderPathExistRecursive(strapiPaths.app.src, this.commonFolderName, config.commonInterfacesFolderName);
-      this.extensions = FileHelpers.ensureFolderPathExistRecursive(strapiPaths.app.src, this.extensionsFolderName);
     }
 
     this.useForApisAndComponents = !!destinationFolder;
@@ -69,7 +68,7 @@ export class DestinationPaths {
       throw new Error(`${pluginName} ⚠️  The given destinationFolder is the same as the Strapi root`);
     }
 
-    if (destinationFolder=== strapiPaths.app.src) {
+    if (destinationFolder === strapiPaths.app.src) {
       throw new Error(`${pluginName} ⚠️  The given destinationFolder is the same as the Strapi src`);
     }
 

--- a/server/schemas-to-ts/converter.ts
+++ b/server/schemas-to-ts/converter.ts
@@ -35,10 +35,10 @@ export class Converter {
       return;
     }
 
-    const commonSchemas: SchemaInfo[] = this.interfaceBuilder.generateCommonSchemas(this.destinationPaths.commons, this.destinationPaths.extensions);
+    const commonSchemas: SchemaInfo[] = this.interfaceBuilder.generateCommonSchemas(this.destinationPaths.commons, this.strapiDirectories.app.extensions);
     const apiSchemas: SchemaInfo[] = this.getSchemas(this.strapiDirectories.app.api, SchemaSource.Api);
     const componentSchemas: SchemaInfo[] = this.getSchemas(this.strapiDirectories.app.components, SchemaSource.Component, apiSchemas);
-    const extensionSchemas: SchemaInfo[] = this.getSchemas(this.destinationPaths.extensions, SchemaSource.Extension);
+    const extensionSchemas: SchemaInfo[] = this.getSchemas(this.strapiDirectories.app.extensions, SchemaSource.Extension);
     this.adjustComponentsWhoseNamesWouldCollide(componentSchemas);
 
     const schemas: SchemaInfo[] = [...apiSchemas, ...componentSchemas, ...commonSchemas, ...extensionSchemas];
@@ -115,8 +115,14 @@ export class Converter {
         folder = this.destinationPaths.commons;
         break;
       case SchemaSource.Extension:
-        schemaName = `Full${schema?.info.displayName}`;
-        folder = this.destinationPaths.useForApisAndComponents ? this.destinationPaths.extensions : path.dirname(file);
+        if (schema?.info.displayName === 'User') {
+          folder = this.destinationPaths.commons;
+        } else {
+          folder = this.destinationPaths.useForApisAndComponents
+          ? FileHelpers.ensureFolderPathExistRecursive(this.config.destinationFolder, this.destinationPaths.extensionsFolderName)
+          : path.dirname(file);
+        }
+        schemaName = schema?.info.displayName;
         break;
       case SchemaSource.Component:
         let fileNameWithoutExtension = path.basename(file, path.extname(file));

--- a/server/schemas-to-ts/converter.ts
+++ b/server/schemas-to-ts/converter.ts
@@ -108,7 +108,7 @@ export class Converter {
     switch (schemaSource) {
       case SchemaSource.Api:
         schemaName = schema?.info.singularName;
-        folder = this.destinationPaths.useForApisAndComponents ? this.destinationPaths.apis : path.dirname(file);
+        folder = this.destinationPaths.useCustomDestinationFolder ? this.destinationPaths.apis : path.dirname(file);
         break;
       case SchemaSource.Common:
         schemaName = schema?.info.displayName;
@@ -126,7 +126,7 @@ export class Converter {
         schemaName = fileNameWithoutExtension;
         folder = path.dirname(file);
         const componentFolder: string = path.basename(folder);
-        folder = this.destinationPaths.useForApisAndComponents
+        folder = this.destinationPaths.useCustomDestinationFolder
           ? FileHelpers.ensureFolderPathExistRecursive(this.destinationPaths.components, componentFolder)
           : FileHelpers.ensureFolderPathExistRecursive(folder, this.destinationPaths.componentInterfacesFolderName);
         break;

--- a/server/schemas-to-ts/converter.ts
+++ b/server/schemas-to-ts/converter.ts
@@ -115,13 +115,10 @@ export class Converter {
         folder = this.destinationPaths.commons;
         break;
       case SchemaSource.Extension:
-        if (schema?.info.displayName === 'User') {
-          folder = this.destinationPaths.commons;
-        } else {
-          folder = this.destinationPaths.useForApisAndComponents
-          ? FileHelpers.ensureFolderPathExistRecursive(this.config.destinationFolder, this.destinationPaths.extensionsFolderName)
-          : path.dirname(file);
+        if (schema?.info.displayName !== 'User') {
+          return;
         }
+        folder = this.destinationPaths.commons;
         schemaName = schema?.info.displayName;
         break;
       case SchemaSource.Component:

--- a/server/schemas-to-ts/interface-builders/interfaceBuilder.ts
+++ b/server/schemas-to-ts/interface-builders/interfaceBuilder.ts
@@ -59,7 +59,7 @@ export abstract class InterfaceBuilder {
     return interfacesFileContent;
   }
 
-  public generateCommonSchemas(commonFolderModelsPath: string, extensionFolderModelsPath?: string): SchemaInfo[] {
+  public generateCommonSchemas(commonFolderModelsPath: string, sourceExtensionFolderModelsPath?: string): SchemaInfo[] {
     const commonSchemas: SchemaInfo[] = [];
     this.addCommonSchema(commonSchemas, commonFolderModelsPath, 'Payload',
       `export interface Payload<T> {
@@ -75,14 +75,8 @@ export abstract class InterfaceBuilder {
     }
     `);
 
-    if (extensionFolderModelsPath && FileHelpers.folderExists(`${extensionFolderModelsPath}/users-permissions/content-types/user`)) {
-      this.addCommonSchema(commonSchemas, commonFolderModelsPath, 'User',
-        `import {FullUser, FullUser_Plain, FullUser_NoRelations} from "../../extensions/users-permissions/content-types/user/FullUser";
-        export interface User extends FullUser {}`,`
-        export interface User_Plain extends FullUser_Plain {}
-        export interface User_NoRelations extends FullUser_NoRelations {}
-    `);
-    } else {
+    if (!sourceExtensionFolderModelsPath 
+      || !FileHelpers.folderExists(`${sourceExtensionFolderModelsPath}/users-permissions/content-types/user`)) {
       this.addCommonSchema(commonSchemas, commonFolderModelsPath, 'User',
         `export interface User {
         id: number;
@@ -506,7 +500,7 @@ export abstract class InterfaceBuilder {
       interfaceText += `${indentation}locale: string;\n`;
       if (schemaType === SchemaType.Standard) {
         interfaceText += `${indentation}localizations?: { data: ${schemaInfo.pascalName}[] };\n`;
-      } else if(schemaType === SchemaType.Plain) {
+      } else if (schemaType === SchemaType.Plain) {
         interfaceText += `${indentation}localizations?: ${schemaInfo.pascalName}${plainClassSuffix}[];\n`;
       } else {
         interfaceText += `${indentation}localizations?: ${schemaInfo.pascalName}[];\n`;


### PR DESCRIPTION
The purpose of this PR is to fix and improve some of the changes made in the PR #57 
Those changes didn't work well in some scenarios, like when a `destinationFolder` is specified in the configuration of the plugin.

Also, as the version of the User class generated when there are extensions is fully compatible with the one generated by default, I didn't see a reason to have 2 different classes (although the way it was implemented in #57 is actually very clever) so I made it into just one class, that will always be in the `common` folder.
In that regard, I also don't see a reason to add the "Full" suffix to extensions classes. I might be missing something here, tho, so I'll wait for @creazy231 to check this out and get back to me.

**A key fix in this PR is that all paths need to be automatically generated by the plugin. Any hardcoded one is bound to fail at some point**.